### PR TITLE
syncMenu align

### DIFF
--- a/poll-taquito/src/components/syncMenu.css
+++ b/poll-taquito/src/components/syncMenu.css
@@ -1,8 +1,9 @@
 .syncMenu-contents {
   position: absolute;
-  right: 0;
-  top: 0;
-  left: 0;
+  right: 10px;
+  top: 10px;
+  /* left: 0; */
+  width: 300px;
   bottom: 0;
   background: var(--gray-0);
 }
@@ -63,8 +64,12 @@
   }
 
   .syncMenu-mobileOnly {
-    padding: calc(var(--grid-unit) * 2);
-    background: var(--gray-20);
+    display: none;
+  }
+  
+  .syncMenu-contents {
+    right: -20px;
+    top: -20px;
   }
 
   .syncMenu-mainOptions {


### PR DESCRIPTION
@depatchedmode I was kind of on a tear today just getting some basic stuff in shape and only realized later that it borked some Storybook stuff. I fixed that now, and while I was there noticed that the syncmenu alignment seemed to jump around. Is the fix I set up here the right approach or is there some other change I made that should be undone?